### PR TITLE
Use npm ci instead of npm install

### DIFF
--- a/into/bin/build
+++ b/into/bin/build
@@ -4,7 +4,7 @@ set -eu
 
 cd $INTO_SOURCE_DIR
 echo "Installing dependencies ..."
-npm install
+npm ci
 
 echo "Building CRA application ..."
 npm run build


### PR DESCRIPTION
Perhaps we should use the ci command instead of install to use the exact packages from package-lock.json

https://docs.npmjs.com/cli/ci.html